### PR TITLE
Refresh the DDGS client periodically

### DIFF
--- a/sopel_search/plugin.py
+++ b/sopel_search/plugin.py
@@ -23,7 +23,7 @@ PLUGIN_OUTPUT_PREFIX = '[search] '
 
 def setup(bot):
     bot.settings.define_section('search', SearchSection)
-    bot.memory['ddg_search_client'] = DDGS()
+    refresh_ddgs_client(bot)
 
 
 def shutdown(bot):
@@ -32,6 +32,15 @@ def shutdown(bot):
 
 def configure(config):
     configure_plugin(config)
+
+
+# recreate the DDGS client hourly to avoid excess `RatelimitException`s
+# it seems to get stale after a while, probably longer than an hour but
+# it's not that expensive to recreate the client more often
+@plugin.interval(60 * 60)
+def refresh_ddgs_client(bot):
+    bot.memory['ddg_search_client'] = DDGS()
+    LOGGER.debug('Refreshed DuckDuckGo search client.')
 
 
 @plugin.commands('search', 'ddg', 'g')

--- a/sopel_search/plugin.py
+++ b/sopel_search/plugin.py
@@ -74,10 +74,16 @@ def search(bot, trigger):
             "`pip install --upgrade duckduckgo-search` to see if there is a "
             "newer version, and restart the bot if so."
         )
+        LOGGER.debug(
+            "Refreshing DDGS client to try to recover from RatelimitException.")
+        refresh_ddgs_client(bot)
         return
     except TimeoutException:
         bot.reply("Sorry, the search request timed out. Try again later.")
         LOGGER.error("Timeout during search request.")
+        LOGGER.debug(
+            "Refreshing DDGS client to try to recover from TimeoutException.")
+        refresh_ddgs_client(bot)
         return
 
     if not results:


### PR DESCRIPTION
Pessimistically running this every hour, though in practice the client seems to be valid for much longer. It's just not that expensive, and the priority is to avoid having searches fail.

_Yes, this is going to merge-conflict with #4, but I didn't want to stack the PRs._