### PR TITLE
Upgrade duckduckgo_search to 8.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Releases are hosted on PyPI, so after installing Sopel, all you need is `pip`:
 $ pip install sopel-search
 ```
 
+This plugin is designed for use with Sopel version 8.0+, but may have a higher
+minimum Python version requirement than Sopel itself.
+
 ### Google query suggestions
 
 If you want users to be able to fetch query suggestions from Google using the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,10 +39,10 @@ keywords = [
   "irc",
 ]
 
-requires-python = ">=3.8, <4"
+requires-python = ">=3.9, <4"  # Python 3.9+ only as of duckduckgo-search 7.3
 dependencies = [
   "sopel>=8.0",
-  "duckduckgo-search~=6.3",
+  "duckduckgo-search>=8.0",
 ]
 
 [project.optional-dependencies]

--- a/sopel_search/plugin.py
+++ b/sopel_search/plugin.py
@@ -61,7 +61,7 @@ def search(bot, trigger):
             keywords=query,
             region=bot.settings.search.region,
             safesearch=bot.settings.search.safesearch,
-            backend='api',
+            backend='auto',
             max_results=1,
         )
     except RatelimitException:


### PR DESCRIPTION
Library version 6.x was returning errors. From now we will stop capping the version. If the library breaks and a newer version works, there's no reason for pip to complain about incompatible dependencies. A new plugin version needs to be released only when breaking changes happen.

The library's currently supported versions require Python 3.9 or higher, so this plugin's requirements have been updated to match.