### PR TITLE
Update license metadata for PEP 639 & update publishing workflow

### DIFF
--- a/.github/workflows/trusted-publishing.yml
+++ b/.github/workflows/trusted-publishing.yml
@@ -8,11 +8,8 @@ permissions:
   contents: read
 
 jobs:
-  upload:
+  build:
     runs-on: ubuntu-latest
-    environment: release
-    permissions:
-      id-token: write
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python
@@ -25,5 +22,23 @@ jobs:
         pip install build
     - name: Build package
       run: python -m build
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: built-distributions
+        path: dist/
+
+  upload:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+    steps:
+    - name: Download build artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: built-distributions
+        path: dist/
     - name: Publish package
-      uses: pypa/gh-action-pypi-publish@81e9d935c883d0b210363ab89cf05f3894778450
+      uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,14 +21,13 @@ authors = [
   { name="dgw", email="dgw@technobabbl.es" },
 ]
 
-license = { text="EFL-2.0" }
+license = "EFL-2.0"
+license-files = ["COPYING"]
 dynamic = ["readme"]
 
 classifiers = [
   "Intended Audience :: Developers",
   "Intended Audience :: System Administrators",
-  "License :: Eiffel Forum License (EFL)",
-  "License :: OSI Approved :: Eiffel Forum License",
   "Programming Language :: Python :: 3 :: Only",
   "Topic :: Communications :: Chat :: Internet Relay Chat",
 ]


### PR DESCRIPTION
Need a newer version of the pypi-publish action to support this updated metadata version, and at the same time I figured it would be wise to pull in the isolated workflow we're using on newer plugins (which splits the build & upload stages into separate jobs with tailored permissions).

Built and tested with `twine check` before PR.