### PR TITLE
Migrate `duckduckgo_search` to `ddgs`

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,16 +11,7 @@ $ pip install sopel-search
 ```
 
 This plugin is designed for use with Sopel version 8.0+, but may have a higher
-minimum Python version requirement than Sopel itself.
-
-### Google query suggestions
-
-If you want users to be able to fetch query suggestions from Google using the
-`.gsuggest` command, you will need the `gsuggest` extra:
-
-```shell
-$ pip install sopel-search[gsuggest]
-```
+minimum Python version requirement than Sopel itself due to upstream libraries.
 
 ## Configuring
 
@@ -35,3 +26,10 @@ which it prompts you. Available settings are:
   query suggestions using `.suggest`.
 * `safesearch`: Controls SafeSearch filtering of `.search` results; one of 'on',
   'moderate', and 'off'.
+
+## Using
+
+Two primary functions are available, `search` and `suggest`:
+
+* `.search` (or `.g`): Perform a text search and return the top result
+* `.suggest`: Fetch autocomplete suggestions for the stem of a search query

--- a/README.md
+++ b/README.md
@@ -31,5 +31,5 @@ which it prompts you. Available settings are:
 
 Two primary functions are available, `search` and `suggest`:
 
-* `.search` (or `.g`): Perform a text search and return the top result
+* `.search` (aliases: `.ddg`, `.g`): Perform a text search and return the top result
 * `.suggest`: Fetch autocomplete suggestions for the stem of a search query

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,15 +38,14 @@ keywords = [
   "irc",
 ]
 
-requires-python = ">=3.9, <4"  # Python 3.9+ only as of duckduckgo-search 7.3
+requires-python = ">=3.9, <4"  # Python 3.9+ only as of ddgs 7.3
 dependencies = [
   "sopel>=8.0",
-  "duckduckgo-search>=8.0",
+  "ddgs>=9.0",
+  # for .suggest
+  "xmltodict~=0.13.0",
+  "requests",  # let Sopel define the version constraint
 ]
-
-[project.optional-dependencies]
-gsuggest = ["xmltodict~=0.13.0", "requests"]
-# Sopel itself requires `requests`, but it's best to be explicit
 
 [project.urls]
 "Homepage" = "https://github.com/sopel-irc/sopel-search"

--- a/sopel_search/plugin.py
+++ b/sopel_search/plugin.py
@@ -126,7 +126,7 @@ def gsuggest(bot, trigger):
         return
 
     query = trigger.group(2)
-    language = bot.settings.search.region.partition('-')[1] or 'en'
+    language = (bot.settings.search.region.partition('-')[1] or 'en').lower()
 
     base = 'https://suggestqueries.google.com/complete/search'
     parameters = {

--- a/sopel_search/plugin.py
+++ b/sopel_search/plugin.py
@@ -63,7 +63,7 @@ def search(bot, trigger):
             query=query,
             region=bot.settings.search.region,
             safesearch=bot.settings.search.safesearch,
-            backend='auto',
+            backend='duckduckgo, google, brave, bing',
             max_results=1,
         )
     except RatelimitException:


### PR DESCRIPTION
The `duckduckgo_search` library renamed to `ddgs` a while ago, along with adding a totally new feature set to direct queries across numerous possible backends.

Some time before that, `.suggest` had stopped working due to changes in the library; `.gsuggest` and `.suggest` now both point to Google's suggestions API. All dependencies are included now; the `gsuggest` extra is removed.

`.suggest` also now uses the plugin's `region` setting to determine which language to request suggestions in. With the default region setting of `us-en`, this means it still requests suggestions in `en`glish.